### PR TITLE
Jp extra leaderboards

### DIFF
--- a/lib/db/users-suggestions.js
+++ b/lib/db/users-suggestions.js
@@ -3,7 +3,7 @@
 var neo4jClient = require('./neo4jclient');
 var speakers = require('./speakers');
 var defaultSuggestions = require('./default-suggestions');
-var MAX_SUGGESTIONS = 10;
+var MAX_SUGGESTIONS = 12;
 var MAX_DEFAULT_SUGGESTIONS = 2;
 
 /**

--- a/src/css/components/leaderboard.css
+++ b/src/css/components/leaderboard.css
@@ -65,6 +65,13 @@
   height:        21px;
   margin:        auto 20px auto 0;
   border-radius: 100%;
+
+
+  &.octicon {
+    color:     white;
+    font-size: 2.5rem;
+  }
+
 }
 
 .leaderboard__items__item__count {

--- a/src/js/layouts/leaderboard-layout.js
+++ b/src/js/layouts/leaderboard-layout.js
@@ -33,12 +33,37 @@ var DistanceCollection = Backbone.Collection.extend({
   },
 });
 
+var RepoCollection = Backbone.Collection.extend({
+  url: '/leaderboards/repo',
+  model: Backbone.Model.extend({
+    initialize: function(attrs) {
+      this.set('icon', 'repo');
+      this.set('link', `https://github.com/${attrs.repoFullName}`);
+      this.set('username', attrs.repoFullName);
+      this.set('count', attrs.score);
+    },
+  }),
+});
+
+var LanguagesCollection = Backbone.Collection.extend({
+  url: '/leaderboards/repo-languages',
+  model: Backbone.Model.extend({
+    initialize: function(attrs) {
+      this.set('icon', 'file-code');
+      this.set('username', attrs.repoLanguage);
+      this.set('count', attrs.score);
+    },
+  }),
+});
+
 export default Marionette.LayoutView.extend({
   template: leaderBoardsTemplate,
 
   regions:     {
     distance:  '[data-component="distance-travelled"]',
     locations: '[data-component="locations"]',
+    repos:     '[data-component="repos"]',
+    languages: '[data-component="languages"]',
   },
 
   onRender: function() {
@@ -51,5 +76,16 @@ export default Marionette.LayoutView.extend({
       model:      new Backbone.Model({ title: 'Hitchhiking Hometowns' }),
       collection: new CountryCollection(),
     }));
+
+    this.repos.show(new LeaderBoardView({
+      model:      new Backbone.Model({ title: 'Repositories Viewed' }),
+      collection: new RepoCollection(),
+    }));
+
+    this.languages.show(new LeaderBoardView({
+      model:      new Backbone.Model({ title: 'Languages Watched' }),
+      collection: new LanguagesCollection(),
+    }));
+
   },
 });

--- a/src/js/views/results-view.js
+++ b/src/js/views/results-view.js
@@ -23,7 +23,7 @@ export default Marionette.CompositeView.extend({
   childViewContainer: '[data-component="results-list"]',
   collection: new ResultsCollection(),
   filter: function(model, index){
-    return index < 10;
+    return index < 12;
   },
 
   initialize: function() {

--- a/src/js/views/results-view.js
+++ b/src/js/views/results-view.js
@@ -7,7 +7,7 @@ var ResultsCollection = Backbone.Collection.extend({
   url: '/user/suggestions',
   model: Backbone.Model.extend({
     defaults: {
-      shouldShowReason: true
+      shouldShowReason: true,
     },
     initialize: function(attrs) {
       this.set('username', attrs.login);
@@ -22,7 +22,7 @@ export default Marionette.CompositeView.extend({
   childView: LeaderBoardItem,
   childViewContainer: '[data-component="results-list"]',
   collection: new ResultsCollection(),
-  filter: function(model, index){
+  filter: function(model, index) {
     return index < 12;
   },
 

--- a/src/templates/leaderboard/item.hbs
+++ b/src/templates/leaderboard/item.hbs
@@ -7,7 +7,16 @@
   <p class="suggestion-content__reason">{{reason}}</p>
 </div>
 {{else}}
+
+
+{{#if image}}
 <img class="leaderboard__items__item__image" alt="{{username}} title=" {{username}} src="{{image}}" />
+{{/if}}
+
+{{#if icon}}
+<span class="leaderboard__items__item__image octicon octicon-{{icon}}"></span>
+{{/if}}
+
 {{#if link}}<a class="leaderboard__link" target="_blank"  href="{{link}}">{{/if}}
   <p class="leaderboard__items__item__username">{{username}}{{#if country}}, {{country}}{{/if}} </p>
 {{#if link}}</a>{{/if}}

--- a/src/templates/leaderboard/layout.hbs
+++ b/src/templates/leaderboard/layout.hbs
@@ -1,11 +1,23 @@
 <section class="leaderboard-container" data-component="index-layout-leaderboard">
   <h1 class="leaderboard-container__title">Leaderboards</h1>
   <div class="leaderboard-container__leaderboards">
+
     <div class="leaderboard-container__leaderboards__leaderboard" data-component="distance-travelled">
       one
     </div>
+
     <div class="leaderboard-container__leaderboards__leaderboard" data-component="locations">
       two
     </div>
+
+    <div class="leaderboard-container__leaderboards__leaderboard" data-component="repos">
+      two
+    </div>
+
+    <div class="leaderboard-container__leaderboards__leaderboard" data-component="languages">
+      two
+    </div>
+
+
   </div>
 </section>


### PR DESCRIPTION
This PR adds extra leaderboards for popular repositories and popular languages:

Desktop:
![desktop-leaderboards](https://cloud.githubusercontent.com/assets/1975139/10159994/06d7046a-6693-11e5-9f4c-9ce4c502adb1.png)

Tablet:
![tablet-leaderboard](https://cloud.githubusercontent.com/assets/1975139/10159997/09501af6-6693-11e5-80a3-fb4cbfd5ec34.png)

Mobile:
![mobile](https://cloud.githubusercontent.com/assets/1975139/10160050/408299c2-6693-11e5-8cbc-36eef701ad3e.png)
